### PR TITLE
Update array functions and memory allocation

### DIFF
--- a/include/libft.h
+++ b/include/libft.h
@@ -6,7 +6,7 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/17 16:26:52 by jschwabe          #+#    #+#             */
-/*   Updated: 2024/01/15 11:31:40 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 16:12:39 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -274,9 +274,9 @@ int			strn_chr(const char *s, int c);
  */
 int			put_nbr(size_t n, char *base, size_t slen);
 void		arr_free(char **arr);
-size_t		arr_len(char **arr);
-char		**arr_dup(char **arr);
-void		print_arr(char **arr);
+size_t		arr_len(const char **arr);
+char		**arr_dup(const char **arr);
+void		print_arr(const char **arr);
 
 /**
  * @brief free the memory, set it to NULL

--- a/src/arr/arr_dup.c
+++ b/src/arr/arr_dup.c
@@ -6,7 +6,7 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/30 20:31:59 by jschwabe          #+#    #+#             */
-/*   Updated: 2023/07/25 15:54:28 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 16:20:04 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 /**
  * @brief strdup but for a 2d array
  */
-char	**arr_dup(char **arr)
+char	**arr_dup(const char **arr)
 {
 	char	**dup;
 	size_t	len;
@@ -24,7 +24,7 @@ char	**arr_dup(char **arr)
 	if (!arr)
 		return (NULL);
 	len = arr_len(arr) + 1;
-	dup = malloc(sizeof(*dup) * (len));
+	dup = (char **) ft_calloc(sizeof(char *), len);
 	if (!dup)
 		return (NULL);
 	i = -1;

--- a/src/arr/arr_len.c
+++ b/src/arr/arr_len.c
@@ -6,7 +6,7 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/30 20:28:02 by jschwabe          #+#    #+#             */
-/*   Updated: 2023/07/25 15:56:03 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 13:10:17 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,7 +15,7 @@
 /**
  * @brief strlen but for an array
  */
-size_t	arr_len(char **arr)
+size_t	arr_len(const char **arr)
 {
 	size_t	len;
 

--- a/src/arr/print_arr.c
+++ b/src/arr/print_arr.c
@@ -6,13 +6,13 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/15 11:23:16 by jschwabe          #+#    #+#             */
-/*   Updated: 2024/01/15 11:23:55 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 13:09:51 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	print_arr(char **arr)
+void	print_arr(const char **arr)
 {
 	int	i;
 

--- a/src/string/ft_strdup.c
+++ b/src/string/ft_strdup.c
@@ -6,7 +6,7 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/25 20:24:13 by jschwabe          #+#    #+#             */
-/*   Updated: 2023/07/25 16:39:03 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 15:59:04 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,7 @@ char	*ft_strdup(const char *s)
 	size_t	size;
 
 	size = ft_strlen(s) + 1;
-	copy = malloc(size);
+	copy = ft_calloc(size, sizeof(char));
 	if (!copy)
 		return (0);
 	ft_memcpy(copy, s, size);

--- a/src/string/ft_substr.c
+++ b/src/string/ft_substr.c
@@ -6,7 +6,7 @@
 /*   By: jschwabe <jschwabe@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/20 19:01:42 by jschwabe          #+#    #+#             */
-/*   Updated: 2023/07/25 16:35:17 by jschwabe         ###   ########.fr       */
+/*   Updated: 2024/01/16 15:58:31 by jschwabe         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,7 @@ char	*ft_substr(char const *s, unsigned int start, size_t len)
 	if (len > slen - start)
 		len = slen - start;
 	len += 1;
-	substr = (char *) malloc(len);
+	substr = (char *) ft_calloc(len, sizeof(char));
 	if (!substr)
 		return (NULL);
 	ft_strlcpy(substr, s + start, len);


### PR DESCRIPTION
Use const for some function definitions. Update `ft_strdup` and `ft_substr` functions in the `string` directory to use `ft_calloc` for memory allocation.
